### PR TITLE
PRO-160 ignore paths mentioned in .spaceignore

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -230,7 +230,7 @@ func push(cmd *cobra.Command, args []string) error {
 
 	// push code & run build steps
 	logger.Printf("%s Pushing your code & running build process...\n", emoji.Package)
-	zippedCode, err := runtime.ZipDir(pushProjectDir)
+	zippedCode, err := runtimeManager.ZipDir(pushProjectDir)
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+
+	ignore "github.com/deta/pc-cli/pkg/ignore"
 )
 
 const (
@@ -18,15 +20,22 @@ const (
 )
 
 var (
+	PythonSkipPattern = `__pycache__`
+
+	NodeSkipPattern = `node_modules`
+
+	ignoreFile      = ".spaceignore"
 	spaceDir        = ".space"
 	projectMetaFile = "meta"
 )
 
 // Manager runtime manager handles files management and other services
 type Manager struct {
-	rootDir         string // working directory of the project
-	spacePath       string // dir for storing project meta
-	projectMetaPath string // path to info file about the project
+	rootDir         string            // working directory of the project
+	spacePath       string            // dir for storing project meta
+	projectMetaPath string            // path to info file about the project
+	skipPaths       *ignore.GitIgnore // skip patterns that need to be ignored for space push
+	ignorePath      string            // .spaceignore path
 }
 
 // NewManager returns a new manager for the root dir of the project
@@ -55,19 +64,32 @@ func NewManager(root *string, initDirs bool) (*Manager, error) {
 		rootDir:         rootDir,
 		spacePath:       spacePath,
 		projectMetaPath: filepath.Join(spacePath, projectMetaFile),
+		ignorePath:      filepath.Join(rootDir, ignoreFile),
 	}
+
+	// not handling error as we don't want cli to crash if .detaignore is not found
+	manager.handleIgnoreFile()
 
 	return manager, nil
 }
 
-// reads the contents of a file, returns contents
-func (m *Manager) readFile(path string) ([]byte, error) {
-	f, err := os.Open(path)
+// handleIgnoreFile build a slice of patterns to skip from .spaceignore file if it exists
+func (m *Manager) handleIgnoreFile() error {
+	contents, err := m.readFile(m.ignorePath)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	defer f.Close()
-	return ioutil.ReadAll(f)
+
+	lines, err := readLines(contents)
+	if err != nil {
+		return err
+	}
+
+	var defaultSkipPatterns = []string{PythonSkipPattern, NodeSkipPattern}
+
+	m.skipPaths = ignore.CompileIgnoreLines(append(defaultSkipPatterns, lines...)...)
+
+	return nil
 }
 
 // StoreProjectMeta stores project meta to disk

--- a/internal/runtime/utils.go
+++ b/internal/runtime/utils.go
@@ -1,101 +1,29 @@
 package runtime
 
 import (
-	"archive/zip"
+	"bufio"
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
-	"strings"
 )
 
-func shouldSkip(path string) bool {
-	skipPaths := []string{"node_modules"}
+func readLines(data []byte) ([]string, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
 
-	for _, skipPath := range skipPaths {
-		if strings.Contains(path, skipPath) {
-			return true
-		}
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
 	}
-	return false
+
+	return lines, scanner.Err()
 }
 
-func ZipDir(sourceDir string) ([]byte, error) {
-
-	// TODO: check if dir exists
-
-	absDir, err := filepath.Abs(sourceDir)
+// reads the contents of a file, returns contents
+func (m *Manager) readFile(path string) ([]byte, error) {
+	f, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve absolute path for dir %s to zip, %w", sourceDir, err)
+		return nil, err
 	}
-
-	files := make(map[string][]byte)
-
-	// go through the dir and read all the files
-	err = filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() {
-			// skip directory if code package (E.g. node_modules)
-			shouldSkip := shouldSkip(path)
-			if shouldSkip {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		if err != nil {
-			return err
-		}
-
-		absPath, err := filepath.Abs(path)
-		if err != nil {
-			return err
-		}
-
-		// relative path of file from absolute locations of dir and path
-		relPath, err := filepath.Rel(absDir, absPath)
-		if err != nil {
-			return err
-		}
-
-		// ensures to use forward slashes
-		relPath = filepath.ToSlash(relPath)
-
-		f, e := os.Open(path)
-		if e != nil {
-			return e
-		}
-		defer f.Close()
-		contents, e := ioutil.ReadAll(f)
-		if e != nil {
-			return e
-		}
-
-		files[relPath] = contents
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("cannot scan contents of dir %s to zip, %w", sourceDir, err)
-	}
-
-	buf := new(bytes.Buffer)
-	w := zip.NewWriter(buf)
-
-	for name, content := range files {
-		f, err := w.Create(name)
-		if err != nil {
-			return nil, fmt.Errorf("cannot compress file %s of dir %s, %w", name, sourceDir, err)
-		}
-		_, err = f.Write(content)
-		if err != nil {
-			return nil, fmt.Errorf("cannot compress file %s of dir %s, %w", name, sourceDir, err)
-		}
-	}
-
-	err = w.Close()
-	if err != nil {
-		return nil, fmt.Errorf("cannot close zip writer for dir %s, %w", sourceDir, err)
-	}
-
-	return buf.Bytes(), nil
+	defer f.Close()
+	return ioutil.ReadAll(f)
 }

--- a/internal/runtime/zip.go
+++ b/internal/runtime/zip.go
@@ -1,0 +1,112 @@
+package runtime
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+func (m *Manager) shouldSkip(path string) (bool, error) {
+	// do not skip .spaceignore file
+	if regexp.MustCompile(ignoreFile).MatchString(path) {
+		return false, nil
+	}
+
+	return m.skipPaths.MatchesPath(path), nil
+}
+
+func (m *Manager) ZipDir(sourceDir string) ([]byte, error) {
+	absDir, err := filepath.Abs(sourceDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve absolute path for dir %s to zip, %w", sourceDir, err)
+	}
+
+	// check if dir exists
+	if stat, err := os.Stat(absDir); err != nil && stat.IsDir() {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("source dir %s not found, %w", absDir, err)
+		}
+	}
+
+	files := make(map[string][]byte)
+
+	// go through the dir and read all the files
+	err = filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+
+		if err != nil {
+			return err
+		}
+
+		// skip if shouldSkip according to skipPaths which are derived from .spaceignore
+		shouldSkip, err := m.shouldSkip(path)
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			if shouldSkip {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if shouldSkip {
+			return nil
+		}
+
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+
+		// relative path of file from absolute locations of dir and path
+		relPath, err := filepath.Rel(absDir, absPath)
+		if err != nil {
+			return err
+		}
+
+		// ensures to use forward slashes
+		relPath = filepath.ToSlash(relPath)
+
+		f, e := os.Open(path)
+		if e != nil {
+			return e
+		}
+		defer f.Close()
+		contents, e := ioutil.ReadAll(f)
+		if e != nil {
+			return e
+		}
+
+		files[relPath] = contents
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot scan contents of dir %s to zip, %w", sourceDir, err)
+	}
+
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+
+	for name, content := range files {
+		fmt.Println(name)
+		f, err := w.Create(name)
+		if err != nil {
+			return nil, fmt.Errorf("cannot compress file %s of dir %s, %w", name, sourceDir, err)
+		}
+		_, err = f.Write(content)
+		if err != nil {
+			return nil, fmt.Errorf("cannot compress file %s of dir %s, %w", name, sourceDir, err)
+		}
+	}
+
+	err = w.Close()
+	if err != nil {
+		return nil, fmt.Errorf("cannot close zip writer for dir %s, %w", sourceDir, err)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/pkg/ignore/ignore.go
+++ b/pkg/ignore/ignore.go
@@ -1,0 +1,216 @@
+/*
+
+** The following piece of code is a modified version of https://github.com/sabhiram/go-gitignore/blob/master/ignore.go **
+
+ignore is a library which returns a new ignorer object which can
+test against various paths. This is particularly useful when trying
+to filter files based on a .gitignore document
+
+The rules for parsing the input file are the same as the ones listed
+in the Git docs here: http://git-scm.com/docs/gitignore
+
+The summarized version of the same has been copied here:
+
+    1. A blank line matches no files, so it can serve as a separator
+       for readability.
+    2. A line starting with # serves as a comment. Put a backslash ("\")
+       in front of the first hash for patterns that begin with a hash.
+    3. Trailing spaces are ignored unless they are quoted with backslash ("\").
+    4. An optional prefix "!" which negates the pattern; any matching file
+       excluded by a previous pattern will become included again. It is not
+       possible to re-include a file if a parent directory of that file is
+       excluded. Git doesn’t list excluded directories for performance reasons,
+       so any patterns on contained files have no effect, no matter where they
+       are defined. Put a backslash ("\") in front of the first "!" for
+       patterns that begin with a literal "!", for example, "\!important!.txt".
+    5. If the pattern ends with a slash, it is removed for the purpose of the
+       following description, but it would only find a match with a directory.
+       In other words, foo/ will match a directory foo and paths underneath it,
+       but will not match a regular file or a symbolic link foo (this is
+       consistent with the way how pathspec works in general in Git).
+    6. If the pattern does not contain a slash /, Git treats it as a shell glob
+       pattern and checks for a match against the pathname relative to the
+       location of the .gitignore file (relative to the toplevel of the work
+       tree if not from a .gitignore file).
+    7. Otherwise, Git treats the pattern as a shell glob suitable for
+       consumption by fnmatch(3) with the FNM_PATHNAME flag: wildcards in the
+       pattern will not match a / in the pathname. For example,
+       "Documentation/*.html" matches "Documentation/git.html" but not
+       "Documentation/ppc/ppc.html" or "tools/perf/Documentation/perf.html".
+    8. A leading slash matches the beginning of the pathname. For example,
+       "/*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".
+    9. Two consecutive asterisks ("**") in patterns matched against full
+       pathname may have special meaning:
+        i.   A leading "**" followed by a slash means match in all directories.
+             For example, "** /foo" matches file or directory "foo" anywhere,
+             the same as pattern "foo". "** /foo/bar" matches file or directory
+             "bar" anywhere that is directly under directory "foo".
+        ii.  A trailing "/**" matches everything inside. For example, "abc/**"
+             matches all files inside directory "abc", relative to the location
+             of the .gitignore file, with infinite depth.
+        iii. A slash followed by two consecutive asterisks then a slash matches
+             zero or more directories. For example, "a/** /b" matches "a/b",
+             "a/x/b", "a/x/y/b" and so on.
+        iv.  Other consecutive asterisks are considered invalid. */
+package ignore
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+////////////////////////////////////////////////////////////
+
+// IgnoreParser is an interface with `MatchesPaths`.
+type IgnoreParser interface {
+	MatchesPath(f string) bool
+	MatchesPathHow(f string) (bool, *IgnorePattern)
+}
+
+////////////////////////////////////////////////////////////
+
+// This function pretty much attempts to mimic the parsing rules
+// listed above at the start of this file
+func getPatternFromLine(line string) (*regexp.Regexp, bool) {
+	// Trim OS-specific carriage returns.
+	line = strings.TrimRight(line, "\r")
+
+	// Strip comments [Rule 2]
+	if strings.HasPrefix(line, `#`) {
+		return nil, false
+	}
+
+	// Trim string [Rule 3]
+	// TODO: Handle [Rule 3], when the " " is escaped with a \
+	line = strings.Trim(line, " ")
+
+	// Exit for no-ops and return nil which will prevent us from
+	// appending a pattern against this line
+	if line == "" {
+		return nil, false
+	}
+
+	// TODO: Handle [Rule 4] which negates the match for patterns leading with "!"
+	negatePattern := false
+	if line[0] == '!' {
+		negatePattern = true
+		line = line[1:]
+	}
+
+	// Handle [Rule 2, 4], when # or ! is escaped with a \
+	// Handle [Rule 4] once we tag negatePattern, strip the leading ! char
+	if regexp.MustCompile(`^(\#|\!)`).MatchString(line) {
+		line = line[1:]
+	}
+
+	// If we encounter a foo/*.blah in a folder, prepend the / char
+	if regexp.MustCompile(`([^\/+])/.*\*\.`).MatchString(line) && line[0] != '/' {
+		line = "/" + line
+	}
+
+	// Handle escaping the "." char
+	line = regexp.MustCompile(`\.`).ReplaceAllString(line, `\.`)
+
+	magicStar := "#$~"
+
+	// Handle "/**/" usage
+	if strings.HasPrefix(line, "/**/") {
+		line = line[1:]
+	}
+	line = regexp.MustCompile(`/\*\*/`).ReplaceAllString(line, `(/|/.+/)`)
+	line = regexp.MustCompile(`\*\*/`).ReplaceAllString(line, `(|.`+magicStar+`/)`)
+	line = regexp.MustCompile(`/\*\*`).ReplaceAllString(line, `(|/.`+magicStar+`)`)
+
+	// Handle escaping the "*" char
+	line = regexp.MustCompile(`\\\*`).ReplaceAllString(line, `\`+magicStar)
+	line = regexp.MustCompile(`\*`).ReplaceAllString(line, `([^/]*)`)
+
+	// Handle escaping the "?" char
+	line = strings.Replace(line, "?", `\?`, -1)
+
+	line = strings.Replace(line, magicStar, "*", -1)
+
+	// Temporary regex
+	var expr = ""
+	if strings.HasSuffix(line, "/") {
+		expr = line + "(|.*)$"
+	} else {
+		expr = line + "(|/.*)$"
+	}
+	if strings.HasPrefix(expr, "/") {
+		expr = "^(|/)" + expr[1:]
+	} else {
+		expr = "^(|.*/)" + expr
+	}
+	pattern, _ := regexp.Compile(expr)
+
+	return pattern, negatePattern
+}
+
+////////////////////////////////////////////////////////////
+
+// IgnorePattern encapsulates a pattern and if it is a negated pattern.
+type IgnorePattern struct {
+	Pattern *regexp.Regexp
+	Negate  bool
+	LineNo  int
+	Line    string
+}
+
+// GitIgnore wraps a list of ignore pattern.
+type GitIgnore struct {
+	patterns []*IgnorePattern
+}
+
+// CompileIgnoreLines accepts a variadic set of strings, and returns a GitIgnore
+// instance which converts and appends the lines in the input to regexp.Regexp
+// patterns held within the GitIgnore objects "patterns" field.
+func CompileIgnoreLines(lines ...string) *GitIgnore {
+	gi := &GitIgnore{}
+	for i, line := range lines {
+		pattern, negatePattern := getPatternFromLine(line)
+		if pattern != nil {
+			// LineNo is 1-based numbering to match `git check-ignore -v` output
+			ip := &IgnorePattern{pattern, negatePattern, i + 1, line}
+			gi.patterns = append(gi.patterns, ip)
+		}
+	}
+	return gi
+}
+
+////////////////////////////////////////////////////////////
+
+// MatchesPath returns true if the given GitIgnore structure would target
+// a given path string `f`.
+func (gi *GitIgnore) MatchesPath(f string) bool {
+	matchesPath, _ := gi.MatchesPathHow(f)
+	return matchesPath
+}
+
+// MatchesPathHow returns true, `pattern` if the given GitIgnore structure would target
+// a given path string `f`.
+// The IgnorePattern has the Line, LineNo fields.
+func (gi *GitIgnore) MatchesPathHow(f string) (bool, *IgnorePattern) {
+	// Replace OS-specific path separator.
+	f = strings.Replace(f, string(os.PathSeparator), "/", -1)
+
+	matchesPath := false
+	var mip *IgnorePattern
+	for _, ip := range gi.patterns {
+		if ip.Pattern.MatchString(f) {
+			// If this is a regular target (not negated with a gitignore
+			// exclude "!" etc)
+			if !ip.Negate {
+				matchesPath = true
+				mip = ip
+			} else if matchesPath {
+				// Negated pattern, and matchesPath is already set
+				matchesPath = false
+			}
+		}
+	}
+	return matchesPath, mip
+}
+
+////////////////////////////////////////////////////////////


### PR DESCRIPTION
Used a modified version of this https://github.com/sabhiram/go-gitignore/blob/master/ignore.go instead of using a custom parser like `deta-cli` because some devs had [issues ](https://discord.com/channels/827546555200438332/827546555669413919/1022675567629303878)with the `deta-cli` `.detaignore`. 