### PR TITLE
refactor: replace alpha domain with deta.space

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -12,7 +12,7 @@ import (
 const (
 	docsUrl          = "https://go.deta.dev/docs/space/alpha"
 	spacefileDocsUrl = "https://go.deta.dev/docs/spacefile/v0"
-	builderUrl       = "https://alpha.deta.space/builder"
+	builderUrl       = "https://deta.space/builder"
 )
 
 func isFlagEmpty(flag string) bool {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	spaceRoot = "https://alpha.deta.space/api"
+	spaceRoot = "https://deta.space/api"
 	//spaceRoot = "http://localhost:9900/api"
 	version = "v0"
 )


### PR DESCRIPTION
Noticed that the CLI still uses alpha.deta.space instead of deta.space for the API endpoint as well as when linking to Builder in the output.