### PR TITLE
add bubbletea debug config for vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to dlv",
+            "type": "go",
+            "debugAdapter": "dlv-dap",
+            "request": "attach",
+            "mode": "remote",
+            "remotePath": "${workspaceFolder}",
+            "port": 2345,
+            "host": "127.0.0.1",
+            "preLaunchTask": "Launch Debugger (Headless)"
+        },
+    ],
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,39 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Launch Debugger (Headless)",
+            "type": "process",
+            "command": [
+                "dlv",
+            ],
+            "args": [
+                "debug",
+                "--headless",
+                "--listen=:2345",
+                "--api-version=2",
+                "${workspaceFolder}/main.go",
+                "--",
+                // "cli", "args", "go", "here"
+            ],
+            "options": {
+                "env": {
+                    "SUNBEAM_HEIGHT": "0"
+                }
+            },
+            "isBackground": true,
+            "problemMatcher": {
+                "owner": "go",
+                "fileLocation": "relative",
+                "pattern": {
+                    "regexp": "^couldn't start listener:",
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^API server listening at:",
+                    "endsPattern": "^Got a connection, launched process"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Debugging bubbletea apps is complex, since most commands needs to take control of stdin/stdout. I wrote a blog post about the debugging setup: https://dev.to/pomdtr/how-to-debug-bubble-tea-applications-in-visual-studio-code-50jp