### PR TITLE
run bubbletea cleanup process after sigint

### DIFF
--- a/pkg/components/spinner/spinner.go
+++ b/pkg/components/spinner/spinner.go
@@ -2,7 +2,6 @@ package spinner
 
 import (
 	"fmt"
-
 	"os"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -30,6 +29,7 @@ type Model struct {
 	Request         func() tea.Msg
 	Quitting        bool
 	Err             error
+	exitCode        int
 }
 
 type Input struct {
@@ -58,7 +58,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c":
-			os.Exit(1)
+			m.exitCode = 1
 			return m, tea.Quit
 		default:
 			return m, nil
@@ -95,12 +95,15 @@ func (m Model) View() string {
 func Run(i *Input) *RequestResponse {
 	program := tea.NewProgram(initialModel(i))
 
-	m, err := program.StartReturningModel()
+	m, err := program.Run()
 	if err != nil {
 		return nil
 	}
 
 	if m, ok := m.(Model); ok {
+		if m.exitCode != 0 {
+			os.Exit(m.exitCode)
+		}
 		return m.RequestResponse
 	}
 

--- a/pkg/components/text/text.go
+++ b/pkg/components/text/text.go
@@ -16,6 +16,7 @@ type Model struct {
 	Prompt    string
 	quitting  bool
 	Err       error
+	exitCode  int
 	Validator func(value string) error
 }
 
@@ -70,7 +71,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 
 		case tea.KeyCtrlC:
-			os.Exit(1)
+			m.exitCode = 1
+			return m, tea.Quit
 		}
 	case errMsg:
 		m.Err = msg
@@ -108,12 +110,15 @@ func (m Model) View() string {
 func Run(i *Input) (string, error) {
 	program := tea.NewProgram(initialModel(i))
 
-	m, err := program.StartReturningModel()
+	m, err := program.Run()
 	if err != nil {
 		return "", err
 	}
 
 	if m, ok := m.(Model); ok {
+		if m.exitCode != 0 {
+			os.Exit(m.exitCode)
+		}
 		if m.TextInput.Value() == "" {
 			return i.Placeholder, nil
 		}

--- a/pkg/components/textarea/textarea.go
+++ b/pkg/components/textarea/textarea.go
@@ -14,6 +14,7 @@ type errMsg error
 type Model struct {
 	TextArea textarea.Model
 	Prompt   string
+	exitCode int
 	Err      error
 }
 
@@ -48,7 +49,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyEsc:
 			return m, tea.Quit
 		case tea.KeyCtrlC:
-			os.Exit(1)
+			m.exitCode = 1
+			return m, tea.Quit
 		default:
 			if !m.TextArea.Focused() {
 				cmd = m.TextArea.Focus()
@@ -79,12 +81,15 @@ func (m Model) View() string {
 func Run(i *Input) (string, error) {
 	program := tea.NewProgram(initialModel(i))
 
-	m, err := program.StartReturningModel()
+	m, err := program.Run()
 	if err != nil {
 		return "", err
 	}
 
 	if m, ok := m.(Model); ok {
+		if m.exitCode != 0 {
+			os.Exit(m.exitCode)
+		}
 		return m.TextArea.Value(), nil
 	}
 


### PR DESCRIPTION
In the current cli, if you type ctrl+c, the terminal cursor is not restored. This pr fixes the issue.

Ideally, I don't think the os.Exit code should be handled in the `pkg` package, but fixing it requires largers change in the cli.

Is also replaced the outdated `StartReturningModel` method by `Run`.