### PR TITLE
fix: use build tag argument

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -128,7 +128,7 @@ func push(cmd *cobra.Command, args []string) error {
 	buildSpinnerInput := spinner.Input{
 		LoadingMsg: "Working on starting your build...",
 		Request: func() tea.Msg {
-			r, err := client.CreateBuild(&api.CreateBuildRequest{AppID: pushProjectID})
+			r, err := client.CreateBuild(&api.CreateBuildRequest{AppID: pushProjectID, Tag: pushTag})
 
 			return spinner.Stop{
 				RequestResponse: spinner.RequestResponse{Response: r, Err: err},


### PR DESCRIPTION
The CLI mentions a `tag` argument in its help text for `space push` and the argument is also mentioned in the Space docs. The `tag` is supported by the API as well when creating a build, but the argument was never actually included as part of the request.