### PR TITLE
PRO-241: follow promotion & installation during push

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -39,7 +39,7 @@ func init() {
 	pushCmd.Flags().StringVarP(&pushProjectID, "id", "i", "", "project id of project to push")
 	pushCmd.Flags().StringVarP(&pushProjectDir, "dir", "d", "./", "src of project to push")
 	pushCmd.Flags().StringVarP(&pushTag, "tag", "t", "", "tag to identify this push")
-	pushCmd.Flags().BoolVarP(&pushOpen, "open", "o", false, "open instance in browser after push")
+	pushCmd.Flags().BoolVarP(&pushOpen, "open", "o", false, "open builder instance/project in browser after push")
 	pushCmd.Flags().BoolVarP(&skipLogs, "skip-logs", "", false, "skip following logs after push")
 	rootCmd.AddCommand(pushCmd)
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -364,7 +364,7 @@ func push(cmd *cobra.Command, args []string) error {
 		logger.Printf(styles.Errorf("\n%s Failed to check if Builder instance was updated. Please check %s", emoji.ErrorExclamation, styles.Codef("%s/%s/develop", builderUrl, releaseProjectID)))
 		return nil
 	}
-	if b.Status != api.Complete {
+	if p.Status != api.Complete {
 		logger.Println(styles.Errorf("\n%s Failed to update Builder instance. Please try again!", emoji.ErrorExclamation))
 		return nil
 	}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -40,7 +40,7 @@ func init() {
 	pushCmd.Flags().StringVarP(&pushProjectDir, "dir", "d", "./", "src of project to push")
 	pushCmd.Flags().StringVarP(&pushTag, "tag", "t", "", "tag to identify this push")
 	pushCmd.Flags().BoolVarP(&pushOpen, "open", "o", false, "open instance in browser after push")
-	pushCmd.Flags().BoolVarP(&skipLogs, "skip-logs", "s", false, "skip following logs after push")
+	pushCmd.Flags().BoolVarP(&skipLogs, "skip-logs", "", false, "skip following logs after push")
 	rootCmd.AddCommand(pushCmd)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,10 @@ require (
 	gotest.tools/v3 v3.3.0
 )
 
-require github.com/aymanbagabas/go-osc52 v1.0.3 // indirect
+require (
+	github.com/aymanbagabas/go-osc52 v1.0.3 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
+)
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/muesli/termenv v0.11.1-0.20220212125758-44cd13922739 h1:QANkGiGr39l1E
 github.com/muesli/termenv v0.11.1-0.20220212125758-44cd13922739/go.mod h1:Bd5NYQ7pd+SrtBSrSNoBBmXlcY8+Xj4BMJgh8qcZrvs=
 github.com/muesli/termenv v0.13.0 h1:wK20DRpJdDX8b7Ek2QfhvqhRQFZ237RGRO0RQ/Iqdy0=
 github.com/muesli/termenv v0.13.0/go.mod h1:sP1+uffeLaEYpyOTb8pLCUctGcGLnoFjSn4YJK5e2bc=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -85,6 +87,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -478,9 +478,10 @@ type GetBuildRequest struct {
 type GetBuildResponse struct {
 	ID     string `json:"id"`
 	Status string `json:"status"`
+	Tag    string `json:"tag"`
 }
 
-func (c *DetaClient) GetBuild(r *GetBuildLogsRequest) (*GetBuildResponse, error) {
+func (c *DetaClient) GetBuild(r *GetBuildRequest) (*GetBuildResponse, error) {
 	i := &requestInput{
 		Root:      spaceRoot,
 		Path:      fmt.Sprintf("/%s/builds/%s", version, r.BuildID),

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -512,8 +512,9 @@ type GetReleasePromotionRequest struct {
 }
 
 type GetReleasePromotionResponse struct {
-	ID     string `json:"id" db:"id"`
-	Status string `json:"status" db:"status"`
+	ID      string `json:"id" db:"id"`
+	Status  string `json:"status" db:"status"`
+	Channel string `json:"channel" db:"channel"`
 }
 
 func (c *DetaClient) GetReleasePromotion(r *GetReleasePromotionRequest) (*GetReleasePromotionResponse, error) {
@@ -545,6 +546,191 @@ func (c *DetaClient) GetReleasePromotion(r *GetReleasePromotionRequest) (*GetRel
 	}
 
 	return &resp, nil
+}
+
+type GetPromotionRequest struct {
+	RevisionID string `json:"revision_id"`
+}
+
+type FetchPromotionResponse struct {
+	Promotions []GetReleasePromotionResponse `json:"promotions"`
+	Page       *Page                         `json:"page"`
+}
+
+func (c *DetaClient) GetPromotionByRevision(r *GetPromotionRequest) (*GetReleasePromotionResponse, error) {
+	i := &requestInput{
+		Root:      spaceRoot,
+		Path:      fmt.Sprintf("/%s/promotions?revision_id=%s&limit=1", version, r.RevisionID),
+		Method:    "GET",
+		NeedsAuth: true,
+		Body:      r,
+	}
+
+	fmt.Printf("%+v \n", i)
+
+	o, err := c.request(i)
+	if err != nil {
+		return nil, err
+	}
+
+	if o.Status != 200 {
+		msg := o.Error.Detail
+		if msg == "" && len(o.Error.Errors) > 0 {
+			msg = o.Error.Errors[0]
+		}
+		return nil, fmt.Errorf("failed to fetch promotions: %v", msg)
+	}
+
+	var fetchResp FetchPromotionResponse
+	err = json.Unmarshal(o.Body, &fetchResp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch promotions: %w", err)
+	}
+
+	var promotion *GetReleasePromotionResponse
+	if len(fetchResp.Promotions) > 0 {
+		promotion = &fetchResp.Promotions[0]
+	}
+
+	if promotion.Channel != "development" {
+		return nil, fmt.Errorf("failed to fetch promotions for revision: %s, no development promotion found", r.RevisionID)
+	}
+
+	return promotion, nil
+}
+
+type GetInstallationByReleaseRequest struct {
+	ReleaseID string `json:"release_id"`
+}
+
+type Installation struct {
+	ID         string `json:"id"`
+	InstanceID string `json:"instance_id"`
+	ReleaseID  string `json:"release_id"`
+	Status     string `json:"status"`
+	CreatedAt  string `json:"created_at"`
+}
+
+type FetchInstallationsResponse struct {
+	Installations []Installation `json:"installations"`
+	Page          *Page          `json:"page"`
+}
+
+func (c *DetaClient) GetInstallationByRelease(r *GetInstallationByReleaseRequest) (*Installation, error) {
+	i := &requestInput{
+		Root:      spaceRoot,
+		Path:      fmt.Sprintf("/%s/installations?release_id=%s&limit=1", version, r.ReleaseID),
+		Method:    "GET",
+		NeedsAuth: true,
+	}
+
+	fmt.Printf("%+v \n", i)
+
+	o, err := c.request(i)
+	fmt.Printf("%+v \n", err)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("%+v \n", o.Error)
+
+	if o.Status != 200 {
+		msg := o.Error.Detail
+		if msg == "" && len(o.Error.Errors) > 0 {
+			msg = o.Error.Errors[0]
+		}
+		return nil, fmt.Errorf("failed to fetch installations: %v", msg)
+	}
+
+	var fetchResp FetchInstallationsResponse
+	err = json.Unmarshal(o.Body, &fetchResp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch installations: %w", err)
+	}
+
+	var installation *Installation
+	if len(fetchResp.Installations) > 0 {
+		installation = &fetchResp.Installations[0]
+	}
+
+	return installation, nil
+}
+
+type GetInstallationRequest struct {
+	ID string `json:"id"`
+}
+
+type FetchInstallationResponse struct {
+	Installations []Installation `json:"installations"`
+	Page          *Page          `json:"page"`
+}
+
+func (c *DetaClient) GetInstallation(r *GetInstallationRequest) (*Installation, error) {
+	i := &requestInput{
+		Root:      spaceRoot,
+		Path:      fmt.Sprintf("/%s/installations/%s", version, r.ID),
+		Method:    "GET",
+		NeedsAuth: true,
+	}
+
+	fmt.Printf("%+v \n", i)
+
+	o, err := c.request(i)
+	fmt.Printf("%+v \n", err)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("%+v \n", o.Error)
+
+	if o.Status != 200 {
+		msg := o.Error.Detail
+		if msg == "" && len(o.Error.Errors) > 0 {
+			msg = o.Error.Errors[0]
+		}
+		return nil, fmt.Errorf("failed to fetch installation: %v", msg)
+	}
+
+	var fetchResp FetchInstallationResponse
+	err = json.Unmarshal(o.Body, &fetchResp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch installation: %w", err)
+	}
+
+	var installation *Installation
+	if len(fetchResp.Installations) > 0 {
+		installation = &fetchResp.Installations[0]
+	}
+
+	return installation, nil
+}
+
+type GetInstallationLogsRequest struct {
+	ID string `json:"id"`
+}
+
+func (c *DetaClient) GetInstallationLogs(r *GetInstallationLogsRequest) (io.ReadCloser, error) {
+	i := &requestInput{
+		Root:             spaceRoot,
+		Path:             fmt.Sprintf("/%s/installations/%s/logs?follow=true", version, r.ID),
+		Method:           "GET",
+		NeedsAuth:        true,
+		ReturnReadCloser: true,
+	}
+
+	o, err := c.request(i)
+	if err != nil {
+		return nil, err
+	}
+
+	if o.Status != 200 {
+		msg := o.Error.Detail
+		if msg == "" && len(o.Error.Errors) > 0 {
+			msg = o.Error.Errors[0]
+		}
+		return nil, fmt.Errorf("failed to create release: %v", msg)
+	}
+	return o.BodyReadCloser, nil
 }
 
 type GetSpaceRequest struct {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -566,8 +566,6 @@ func (c *DetaClient) GetPromotionByRevision(r *GetPromotionRequest) (*GetRelease
 		Body:      r,
 	}
 
-	fmt.Printf("%+v \n", i)
-
 	o, err := c.request(i)
 	if err != nil {
 		return nil, err
@@ -624,15 +622,10 @@ func (c *DetaClient) GetInstallationByRelease(r *GetInstallationByReleaseRequest
 		NeedsAuth: true,
 	}
 
-	fmt.Printf("%+v \n", i)
-
 	o, err := c.request(i)
-	fmt.Printf("%+v \n", err)
 	if err != nil {
 		return nil, err
 	}
-
-	fmt.Printf("%+v \n", o.Error)
 
 	if o.Status != 200 {
 		msg := o.Error.Detail
@@ -660,11 +653,6 @@ type GetInstallationRequest struct {
 	ID string `json:"id"`
 }
 
-type FetchInstallationResponse struct {
-	Installations []Installation `json:"installations"`
-	Page          *Page          `json:"page"`
-}
-
 func (c *DetaClient) GetInstallation(r *GetInstallationRequest) (*Installation, error) {
 	i := &requestInput{
 		Root:      spaceRoot,
@@ -673,15 +661,10 @@ func (c *DetaClient) GetInstallation(r *GetInstallationRequest) (*Installation, 
 		NeedsAuth: true,
 	}
 
-	fmt.Printf("%+v \n", i)
-
 	o, err := c.request(i)
-	fmt.Printf("%+v \n", err)
 	if err != nil {
 		return nil, err
 	}
-
-	fmt.Printf("%+v \n", o.Error)
 
 	if o.Status != 200 {
 		msg := o.Error.Detail
@@ -691,18 +674,13 @@ func (c *DetaClient) GetInstallation(r *GetInstallationRequest) (*Installation, 
 		return nil, fmt.Errorf("failed to fetch installation: %v", msg)
 	}
 
-	var fetchResp FetchInstallationResponse
-	err = json.Unmarshal(o.Body, &fetchResp)
+	var resp Installation
+	err = json.Unmarshal(o.Body, &resp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch installation: %w", err)
 	}
 
-	var installation *Installation
-	if len(fetchResp.Installations) > 0 {
-		installation = &fetchResp.Installations[0]
-	}
-
-	return installation, nil
+	return &resp, nil
 }
 
 type GetInstallationLogsRequest struct {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -707,7 +707,7 @@ func (c *DetaClient) GetInstallationLogs(r *GetInstallationLogsRequest) (io.Read
 		if msg == "" && len(o.Error.Errors) > 0 {
 			msg = o.Error.Errors[0]
 		}
-		return nil, fmt.Errorf("failed to create release: %v", msg)
+		return nil, fmt.Errorf("failed to get installation logs: %v", msg)
 	}
 	return o.BodyReadCloser, nil
 }

--- a/pkg/components/emoji/codes.go
+++ b/pkg/components/emoji/codes.go
@@ -27,4 +27,5 @@ var (
 	Pistol           = Emoji{Emoji: "🔫 ", Fallback: ""}
 	Tools            = Emoji{Emoji: "💻 ", Fallback: styles.Info}
 	CrystalBall      = Emoji{Emoji: "🔮 ", Fallback: ""}
+	Label            = Emoji{Emoji: "🏷️ ", Fallback: ""}
 )


### PR DESCRIPTION
- follows the progress of creating the dev release promotion and installation/update of the Builder instance
- adds a `--open` argument that opens the updated Builder instance in the default browser
- adds a `--skip-logs` argument that skips following the build logs and instead exists as soon as the build is started