### PR TITLE
Trace added files and zip size in push command

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -28,6 +28,7 @@ var (
 	pushTag        string
 	pushOpen       bool
 	skipLogs       bool
+	verbose        bool
 	pushCmd        = &cobra.Command{
 		Use:   "push [flags]",
 		Short: "push code for project",
@@ -41,6 +42,7 @@ func init() {
 	pushCmd.Flags().StringVarP(&pushTag, "tag", "t", "", "tag to identify this push")
 	pushCmd.Flags().BoolVarP(&pushOpen, "open", "o", false, "open builder instance/project in browser after push")
 	pushCmd.Flags().BoolVarP(&skipLogs, "skip-logs", "", false, "skip following logs after push")
+	pushCmd.Flags().BoolVarP(&verbose, "verbose", "", false, "verbose output during push")
 	rootCmd.AddCommand(pushCmd)
 }
 
@@ -258,7 +260,7 @@ func push(cmd *cobra.Command, args []string) error {
 
 	// push code & run build steps
 	logger.Printf("\n%s Pushing your code & running build process...\n", emoji.Package)
-	zippedCode, err := runtimeManager.ZipDir(pushProjectDir)
+	zippedCode, err := runtimeManager.ZipDir(pushProjectDir, verbose)
 	if err != nil {
 		return err
 	}

--- a/internal/runtime/zip.go
+++ b/internal/runtime/zip.go
@@ -24,7 +24,7 @@ func (m *Manager) shouldSkip(path string) (bool, error) {
 	return m.skipPaths.MatchesPath(path), nil
 }
 
-func (m *Manager) ZipDir(sourceDir string) ([]byte, error) {
+func (m *Manager) ZipDir(sourceDir string, verbose bool) ([]byte, error) {
 	absDir, err := filepath.Abs(sourceDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve absolute path for dir %s to zip, %w", sourceDir, err)
@@ -87,6 +87,9 @@ func (m *Manager) ZipDir(sourceDir string) ([]byte, error) {
 		}
 
 		files[relPath] = contents
+		if verbose {
+			fmt.Println("adding file", relPath, "of size", len(contents))
+		}
 		return nil
 	})
 	if err != nil {
@@ -112,5 +115,8 @@ func (m *Manager) ZipDir(sourceDir string) ([]byte, error) {
 		return nil, fmt.Errorf("cannot close zip writer for dir %s, %w", sourceDir, err)
 	}
 
+	if verbose {
+		fmt.Println("zip size", len(buf.Bytes()))
+	}
 	return buf.Bytes(), nil
 }


### PR DESCRIPTION
This PR adds the `--verbose` flag to print names of the files added to the zip archive to send to Space servers. Also, with this flag, `space push` prints the size of the zip archive after creating it.

This flag allows us to debug the situations of "hanging" and eventually falling pushes caused my accidentally not ignoring local files, for example, from the `.venv` or `.git` directories.