### PR TITLE
Add push upload spinner

### DIFF
--- a/internal/api/spinner.go
+++ b/internal/api/spinner.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"fmt"
+)
+
+const arrows = "|\\-/"
+
+type ReadSpinner struct {
+	name   string
+	length int64
+	read   int64
+	index  int
+}
+
+func NewReadSpinner(name string, length int64) *ReadSpinner {
+	return &ReadSpinner{name, length, 0, 0}
+}
+
+func (s *ReadSpinner) next() string {
+	s.index = (s.index + 1) % len(arrows)
+	return arrows[s.index : s.index+1]
+}
+
+func (s *ReadSpinner) Status(read int) {
+	s.read += int64(read)
+	var percentage int64
+	if s.length != 0 {
+		percentage = s.read * 100 / s.length
+	}
+	fmt.Printf(
+		"[%s] %s%02d%% %d / %d\r", s.next(), s.name,
+		percentage, s.read, s.length,
+	)
+}


### PR DESCRIPTION
This PR adds a console spinner for the push command.

On a slow network, when `space push` is pushing >10MB zip, which is quite common even for a middle-size micro, it is helpful to see what is going on instead of just seeing "a stuck console" of `space` CLI.

Here is the example how the spinner looks - https://asciinema.org/a/xyGwSesPhkXqpyLR3cr9BaOOl