### PR TITLE
feat: new publishing flow

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -71,11 +71,10 @@
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}",
+            "console": "integratedTerminal",
             "args": [
                 "release",
-                "-d=starters/python-app",
-                "--notes='Release notes'",
-                "--latest"
+                "-d=${env:HOME}/dev/tests/svelte-kit-local2",
             ]
         },
         {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -11,10 +11,8 @@ import (
 	"github.com/deta/space/cmd/shared"
 	"github.com/deta/space/internal/api"
 	"github.com/deta/space/internal/auth"
-	"github.com/deta/space/internal/discovery"
 	"github.com/deta/space/internal/runtime"
 	"github.com/deta/space/internal/spacefile"
-	"github.com/deta/space/pkg/components/confirm"
 	"github.com/deta/space/pkg/components/emoji"
 	"github.com/deta/space/pkg/components/styles"
 	"github.com/pkg/browser"
@@ -76,23 +74,6 @@ func push(projectID string, projectDir string, pushTag string, openInBrowser boo
 	if err != nil {
 		shared.Logger.Printf("%s Failed to parse Spacefile: %s", emoji.ErrorExclamation, err)
 		return err
-	}
-
-	// migrate app name from spacefile to discovery file if present
-	if s.AppName != "" {
-		shared.Logger.Printf("\n%s The %s field was recently moved from the Spacefile to the Discovery.md file.\n\n", emoji.ErrorExclamation, styles.Code("app_name"))
-
-		migrateAppName, err := confirm.Run(fmt.Sprintf("Do you want to move %s from your Spacefile to the Discovery.md file automatically? (y/n)", styles.Code("app_name")))
-		if err != nil {
-			return fmt.Errorf("problem while trying to get confirmation to migrate app_name, %w", err)
-		}
-
-		if !migrateAppName {
-			shared.Logger.Println(styles.Errorf("Please manually move the app_name field from the Spacefile to the Discovery.md file before pushing."))
-			return nil
-		}
-
-		discovery.MigrateAppNameToDiscovery(projectDir, s)
 	}
 
 	shared.Logger.Printf(styles.Green("\nYour Spacefile looks good, proceeding with your push!"))

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -69,7 +69,7 @@ func newCmdRelease() *cobra.Command {
 			}
 
 			// check there are no previous releases for this project
-			if len(res.Releases) < 1 {
+			if len(res.Releases) < 1 && shared.IsOutputInteractive() {
 				if !cmd.Flags().Changed("confirm") {
 					continueReleasing, err := confirmReleasing(listedRelease)
 					if err != nil {

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -216,8 +216,7 @@ func getDiscoveryData(projectDir string) (*sharedTypes.DiscoveryFrontmatter, err
 	df, err := discovery.Open(projectDir)
 	if err != nil {
 		if errors.Is(err, discovery.ErrDiscoveryFileNotFound) {
-			shared.Logger.Println(styles.Errorf("%s No Discovery file found\n", emoji.ErrorExclamation))
-			shared.Logger.Printf("Please give your app a friendly name and add a short description so others know what this app does.\n\n")
+			shared.Logger.Printf("\nPlease give your app a friendly name and add a short description so others know what this app does.\n\n")
 
 			name, err := text.Run(&text.Input{
 				Prompt:      "App Name (max 12 chars)",
@@ -239,7 +238,13 @@ func getDiscoveryData(projectDir string) (*sharedTypes.DiscoveryFrontmatter, err
 			}
 			discoveryData.Tagline = tagline
 
-			discovery.CreateDiscoveryFile(projectDir, *discoveryData)
+			err = discovery.CreateDiscoveryFile(projectDir, *discoveryData)
+			if err != nil {
+				shared.Logger.Println(styles.Errorf("\n%s Failed to read Discovery file, %v", emoji.ErrorExclamation, err))
+				return nil, err
+			}
+
+			shared.Logger.Printf("\n%s Created a new Discovery.md file that stores this data!\n\n", emoji.Check)
 		} else if errors.Is(err, discovery.ErrDiscoveryFileWrongCase) {
 			shared.Logger.Println(styles.Errorf("\n%s The Discovery file must be called exactly 'Discovery.md'", emoji.ErrorExclamation))
 			return nil, err

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -5,15 +5,20 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/adrg/frontmatter"
 	"github.com/deta/space/cmd/shared"
 	"github.com/deta/space/internal/api"
 	"github.com/deta/space/internal/auth"
+	"github.com/deta/space/internal/discovery"
 	"github.com/deta/space/internal/runtime"
 	"github.com/deta/space/pkg/components/choose"
 	"github.com/deta/space/pkg/components/confirm"
 	"github.com/deta/space/pkg/components/emoji"
 	"github.com/deta/space/pkg/components/styles"
+	"github.com/deta/space/pkg/components/text"
+	sharedTypes "github.com/deta/space/shared"
 	"github.com/spf13/cobra"
 )
 
@@ -51,6 +56,56 @@ func newCmdRelease() *cobra.Command {
 				projectID = projectMeta.ID
 			}
 
+			res, err := shared.Client.GetLatestReleaseByApp(projectID)
+			if err != nil {
+				shared.Logger.Println(styles.Errorf("%s Failed to fetch releases: %v", emoji.ErrorExclamation, err))
+				os.Exit(1)
+			}
+
+			// check there are no previous releases for this project
+			if len(res.Releases) < 1 {
+				if !cmd.Flags().Changed("confirm") {
+					continueReleasing, err := confirmReleasing(listedRelease)
+					if err != nil {
+						os.Exit(1)
+					}
+
+					if !continueReleasing {
+						shared.Logger.Println("Aborted releasing this app.")
+						os.Exit(1)
+					}
+				}
+			}
+
+			discoveryData, err := getDiscoveryData(projectDir)
+			if err != nil {
+				shared.Logger.Println(styles.Errorf("%s Error: %v", emoji.ErrorExclamation, err))
+				os.Exit(1)
+			}
+
+			if len(res.Releases) > 0 {
+				latestRelease := res.Releases[0]
+				if latestRelease.Discovery.ContentRaw != "" && latestRelease.Discovery.ContentRaw != discoveryData.ContentRaw {
+					shared.Logger.Println("\nWarning: your local Discovery data is different from the latest release's Discovery data.")
+
+					updateLocalDiscovery, err := confirm.Run("Do you want to update your local Discovery.md file with the data from the latest release?")
+					if err != nil {
+						shared.Logger.Println("Aborted releasing this app.")
+						os.Exit(1)
+					}
+
+					if !updateLocalDiscovery {
+						continueReleasing, err := confirm.Run("Are you sure you want to continue releasing the app with the local Discovery data?")
+						if err != nil || !continueReleasing {
+							shared.Logger.Println("Aborted releasing this app.")
+							os.Exit(1)
+						}
+					} else {
+						// update local Discovery.md file
+					}
+				}
+			}
+
 			if !cmd.Flags().Changed("rid") {
 				if !cmd.Flags().Changed("confirm") {
 					useLatestRevision, err = confirm.Run("Do you want to use the latest revision?")
@@ -70,7 +125,7 @@ func newCmdRelease() *cobra.Command {
 			}
 
 			shared.Logger.Printf(getCreatingReleaseMsg(listedRelease, useLatestRevision))
-			if err := release(projectDir, projectID, revisionID, releaseVersion, listedRelease, releaseNotes); err != nil {
+			if err := release(projectDir, projectID, revisionID, releaseVersion, listedRelease, releaseNotes, discoveryData); err != nil {
 				os.Exit(1)
 			}
 		},
@@ -87,6 +142,98 @@ func newCmdRelease() *cobra.Command {
 	cmd.MarkFlagsMutuallyExclusive("confirm", "rid")
 
 	return cmd
+}
+
+func confirmReleasing(listedRelease bool) (bool, error) {
+	var confirmMsg string
+
+	if listedRelease {
+		shared.Logger.Println("Creating a listed release makes your app available on Deta Discovery for anyone to install and use.")
+		confirmMsg = "Are you sure you want to release this app publicly on Discovery? (y/n)"
+	} else {
+		shared.Logger.Println("Releasing makes your app available via a unique link for others to install and use.")
+		confirmMsg = "Are you sure you want to release this app to others? (y/n)"
+	}
+	shared.Logger.Printf("If you only want to use this app yourself, use your Builder instance instead.\n\n")
+
+	continueReleasing, err := confirm.Run(confirmMsg)
+	if err != nil {
+		return false, fmt.Errorf("problem while trying to get confirmation to continue releasing this project, %w", err)
+	}
+
+	return continueReleasing, nil
+}
+
+func validatePromptValue(value string, min int, max int) error {
+	if len(value) < min {
+		return fmt.Errorf("must be at least %v characters long", min)
+	}
+
+	if len(value) > max {
+		return fmt.Errorf("must be at most %v characters long", max)
+	}
+
+	return nil
+}
+
+func validateAppName(value string) error {
+	return validatePromptValue(value, 4, 12)
+}
+
+func validateAppDescription(value string) error {
+	return validatePromptValue(value, 4, 69)
+}
+
+func getDiscoveryData(projectDir string) (*sharedTypes.DiscoveryFrontmatter, error) {
+	discoveryData := &sharedTypes.DiscoveryFrontmatter{}
+
+	df, err := discovery.Open(projectDir)
+	if err != nil {
+		if errors.Is(err, discovery.ErrDiscoveryFileNotFound) {
+			shared.Logger.Println(styles.Errorf("%s No Discovery file found\n", emoji.ErrorExclamation))
+			shared.Logger.Printf("Please give your app a friendly name and add a short description so others know what this app does.\n\n")
+
+			name, err := text.Run(&text.Input{
+				Prompt:      "App Name (max 12 chars)",
+				Placeholder: "",
+				Validator:   validateAppName,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("problem while trying to get title from text prompt, %w", err)
+			}
+			discoveryData.AppName = name
+
+			tagline, err := text.Run(&text.Input{
+				Prompt:      "Short Description (max 69 chars)",
+				Placeholder: "",
+				Validator:   validateAppDescription,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("problem while trying to get tagline from text prompt, %w", err)
+			}
+			discoveryData.Tagline = tagline
+
+			discovery.CreateDiscoveryFile("Discovery.md", *discoveryData)
+		} else if errors.Is(err, discovery.ErrDiscoveryFileWrongCase) {
+			shared.Logger.Println(styles.Errorf("\n%s The Discovery file must be called exactly 'Discovery.md'", emoji.ErrorExclamation))
+			return nil, err
+		} else {
+			shared.Logger.Println(styles.Errorf("\n%s Failed to read Discovery file, %v", emoji.ErrorExclamation, err))
+			return nil, err
+		}
+	} else {
+		dfstr := string(df)
+
+		rest, err := frontmatter.Parse(strings.NewReader(dfstr), &discoveryData)
+		if err != nil {
+			shared.Logger.Println(styles.Errorf("\n%s Failed to parse Discovery file, %v", emoji.ErrorExclamation, err))
+			return nil, err
+		}
+
+		discoveryData.ContentRaw = string(rest)
+	}
+
+	return discoveryData, nil
 }
 
 func selectRevision(projectID string, useLatestRevision bool) (*api.Revision, error) {
@@ -133,7 +280,7 @@ func selectRevision(projectID string, useLatestRevision bool) (*api.Revision, er
 	return revisionMap[tag], nil
 }
 
-func release(projectDir string, projectID string, revisionID string, releaseVersion string, listedRelease bool, releaseNotes string) (err error) {
+func release(projectDir string, projectID string, revisionID string, releaseVersion string, listedRelease bool, releaseNotes string, discoveryData *sharedTypes.DiscoveryFrontmatter) (err error) {
 	cr, err := shared.Client.CreateRelease(&api.CreateReleaseRequest{
 		RevisionID:    revisionID,
 		AppID:         projectID,
@@ -150,6 +297,13 @@ func release(projectDir string, projectID string, revisionID string, releaseVers
 		shared.Logger.Println(styles.Errorf("%s Failed to create release: %v", emoji.ErrorExclamation, err))
 		return err
 	}
+
+	err = shared.Client.StoreDiscoveryData(cr.ID, discoveryData)
+	if err != nil {
+		shared.Logger.Println(styles.Errorf("%s Error: %v", emoji.ErrorExclamation, err))
+		return err
+	}
+
 	readCloser, err := shared.Client.GetReleaseLogs(&api.GetReleaseLogsRequest{
 		ID: cr.ID,
 	})
@@ -158,11 +312,17 @@ func release(projectDir string, projectID string, revisionID string, releaseVers
 		return err
 	}
 
+	var releaseUrl string
+
 	defer readCloser.Close()
 	scanner := bufio.NewScanner(readCloser)
 	for scanner.Scan() {
 		line := scanner.Text()
-		fmt.Println(line)
+		if strings.Contains(line, "http") {
+			releaseUrl = line
+		} else {
+			fmt.Println(line)
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		shared.Logger.Printf("%s Error: %v\n", emoji.ErrorExclamation, err)
@@ -177,11 +337,15 @@ func release(projectDir string, projectID string, revisionID string, releaseVers
 
 	if r.Status == api.Complete {
 		shared.Logger.Println()
-		shared.Logger.Println(emoji.Rocket, "Lift off -- successfully created a new Release!")
-		shared.Logger.Println(emoji.Earth, "Your Release is available globally on 5 Deta Edges")
+		shared.Logger.Println(emoji.Rocket, "Lift off -- successfully created a new release!")
+		shared.Logger.Println(emoji.Earth, "Your release is available globally on 5 Deta Edges")
 		shared.Logger.Println(emoji.PartyFace, "Anyone can install their own copy of your app.")
 		if listedRelease {
 			shared.Logger.Println(emoji.CrystalBall, "Listed on Discovery for others to find!")
+		}
+
+		if releaseUrl != "" {
+			shared.Logger.Printf("\nRelease: %s", styles.Code(releaseUrl))
 		}
 	} else {
 		shared.Logger.Println(styles.Errorf("\n%s Failed to create release. Please try again!", emoji.ErrorExclamation))
@@ -198,7 +362,7 @@ func getCreatingReleaseMsg(listed bool, latest bool) string {
 		listedInfo = " listed"
 	}
 	if latest {
-		latestInfo = " with the latest Revision"
+		latestInfo = " with the latest revision"
 	}
-	return fmt.Sprintf("\n%s Creating a%s Release%s ...\n\n", emoji.Package, listedInfo, latestInfo)
+	return fmt.Sprintf("\n%s Creating a%s 4elease%s ...\n\n", emoji.Package, listedInfo, latestInfo)
 }

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -186,7 +186,7 @@ func compareDiscoveryData(discoveryData *sharedTypes.DiscoveryFrontmatter, lates
 		}
 
 		if modTime.Before(parsedTime) {
-			shared.Logger.Println("\nWarning: your local Discovery data is different from the latest release's Discovery data.\n")
+			shared.Logger.Print("\nWarning: your local Discovery data is different from the latest release's Discovery data.\n\n")
 
 			updateLocalDiscovery, err := confirm.Run("Do you want to update your local Discovery.md file with the data from the latest release?")
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/adrg/frontmatter v0.2.0 // indirect
 	github.com/aymanbagabas/go-osc52 v1.0.3 // indirect
 	github.com/cloudflare/circl v1.1.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
@@ -31,6 +33,7 @@ require (
 	golang.org/x/oauth2 v0.6.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/deta/space
 go 1.19
 
 require (
-	github.com/alessio/shellescape v1.4.1
 	github.com/adrg/frontmatter v0.2.0
+	github.com/alessio/shellescape v1.4.1
 	github.com/charmbracelet/bubbles v0.14.0
 	github.com/charmbracelet/bubbletea v0.23.1
 	github.com/charmbracelet/lipgloss v0.6.0
@@ -21,8 +21,8 @@ require (
 )
 
 require (
-	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/aymanbagabas/go-osc52 v1.0.3 // indirect
 	github.com/cloudflare/circl v1.1.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
@@ -34,7 +34,6 @@ require (
 	golang.org/x/oauth2 v0.6.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/alessio/shellescape v1.4.1
+	github.com/adrg/frontmatter v0.2.0
 	github.com/charmbracelet/bubbles v0.14.0
 	github.com/charmbracelet/bubbletea v0.23.1
 	github.com/charmbracelet/lipgloss v0.6.0
@@ -13,6 +14,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.2.0
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.3.0
 	mvdan.cc/sh/v3 v3.6.0
@@ -21,7 +23,6 @@ require (
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/adrg/frontmatter v0.2.0 // indirect
 	github.com/aymanbagabas/go-osc52 v1.0.3 // indirect
 	github.com/cloudflare/circl v1.1.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVK
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/adrg/frontmatter v0.2.0 h1:/DgnNe82o03riBd1S+ZDjd43wAmC6W35q67NHeLkPd4=
+github.com/adrg/frontmatter v0.2.0/go.mod h1:93rQCj3z3ZlwyxxpQioRKC1wDLto4aXHrbqIsnH9wmE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52 v1.0.3 h1:DTwqENW7X9arYimJrPeGZcV0ln14sGMt3pHZspWD+Mg=
@@ -150,6 +154,9 @@ google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscL
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	spaceRoot = "https://deta.space/api"
-	//spaceRoot = "http://localhost:9900/api"
-	version = "v0"
+	//spaceRoot = "https://deta.space/api"
+	spaceRoot = "http://localhost:9900/api"
+	version   = "v0"
 )
 
 var (

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -831,10 +831,10 @@ func (c *DetaClient) ListProjectKeys(AppID string) (*ListProjectResponse, error)
 }
 
 type Release struct {
-	ID         string                       `json:"id"`
-	Tag        string                       `json:"tag"`
-	ReleasedAt string                       `json:"released_at"`
-	Discovery  *shared.DiscoveryFrontmatter `json:"discovery"`
+	ID         string                `json:"id"`
+	Tag        string                `json:"tag"`
+	ReleasedAt string                `json:"released_at"`
+	Discovery  *shared.DiscoveryData `json:"discovery"`
 }
 
 type fetchReleasesResponse struct {
@@ -881,7 +881,7 @@ func (c *DetaClient) GetLatestReleaseByApp(appID string) (*GetReleasesResponse, 
 	return &GetReleasesResponse{Releases: releases}, nil
 }
 
-func (c *DetaClient) StoreDiscoveryData(PromotionID string, r *shared.DiscoveryFrontmatter) error {
+func (c *DetaClient) StoreDiscoveryData(PromotionID string, r *shared.DiscoveryData) error {
 	i := &requestInput{
 		Root:      spaceRoot,
 		Path:      fmt.Sprintf("/%s/promotions/%s/discovery", version, PromotionID),

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -831,10 +831,10 @@ func (c *DetaClient) ListProjectKeys(AppID string) (*ListProjectResponse, error)
 }
 
 type Release struct {
-	ID        string                       `json:"id"`
-	Tag       string                       `json:"tag"`
-	CreatedAt string                       `json:"created_at"`
-	Discovery *shared.DiscoveryFrontmatter `json:"discovery"`
+	ID         string                       `json:"id"`
+	Tag        string                       `json:"tag"`
+	ReleasedAt string                       `json:"released_at"`
+	Discovery  *shared.DiscoveryFrontmatter `json:"discovery"`
 }
 
 type fetchReleasesResponse struct {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	//spaceRoot = "https://deta.space/api"
-	spaceRoot = "http://localhost:9900/api"
-	version   = "v0"
+	spaceRoot = "https://deta.space/api"
+	//spaceRoot = "http://localhost:9900/api"
+	version = "v0"
 )
 
 var (

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -3,7 +3,6 @@ package discovery
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -24,7 +23,7 @@ var (
 )
 
 func checkDiscoveryFileCase(sourceDir string) (string, bool, error) {
-	files, err := ioutil.ReadDir(sourceDir)
+	files, err := os.ReadDir(sourceDir)
 	if err != nil {
 		return "", false, err
 	}
@@ -50,6 +49,7 @@ func CreateDiscoveryFile(name string, discovery shared.DiscoveryData) error {
 	fmt.Fprintln(f, "---")
 	fmt.Fprint(f, string(js))
 	fmt.Fprintln(f, "---")
+	fmt.Fprintln(f)
 	fmt.Fprintln(f, discovery.ContentRaw)
 
 	err = f.Close()

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -133,7 +133,7 @@ func MigrateAppNameToDiscovery(projectDir string, s *spacefile.Spacefile) {
 	}
 
 	discoveryData.AppName = s.AppName
-	err = CreateDiscoveryFile("Discovery.md", *discoveryData)
+	err = CreateDiscoveryFile(DiscoveryFilename, *discoveryData)
 	if err != nil {
 		cmdShared.Logger.Println(styles.Errorf("\n%s Failed to create Discovery file, %v", emoji.ErrorExclamation, err))
 		cmdShared.Logger.Println(styles.Error("\nPlease manually move the app_name from the Spacefile to the Discovery.md file before pushing."))
@@ -144,7 +144,7 @@ func MigrateAppNameToDiscovery(projectDir string, s *spacefile.Spacefile) {
 
 	err = s.Save(projectDir)
 	if err != nil {
-		cmdShared.Logger.Println(styles.Errorf("\n%s failed to modify spacefile in %s, %w", emoji.ErrorExclamation, projectDir, err))
+		cmdShared.Logger.Println(styles.Errorf("\n%s failed to modify spacefile in %s, %v", emoji.ErrorExclamation, projectDir, err))
 		return
 	}
 }

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/adrg/frontmatter"
 	cmdShared "github.com/deta/space/cmd/shared"
@@ -78,8 +79,22 @@ func Open(sourceDir string) ([]byte, error) {
 	return c, nil
 }
 
-func CreateDiscoveryFile(filename string, discovery shared.DiscoveryFrontmatter) error {
-	f, err := os.Create(filename)
+func GetDiscoveryFileLastChanged(sourceDir string) (time.Time, error) {
+	p := filepath.Join(sourceDir, DiscoveryFilename)
+	file, err := os.Stat(p)
+
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	modifiedtime := file.ModTime()
+
+	return modifiedtime, nil
+}
+
+func CreateDiscoveryFile(sourceDir string, discovery shared.DiscoveryFrontmatter) error {
+	p := filepath.Join(sourceDir, DiscoveryFilename)
+	f, err := os.Create(p)
 	if err != nil {
 		f.Close()
 		return err
@@ -89,6 +104,7 @@ func CreateDiscoveryFile(filename string, discovery shared.DiscoveryFrontmatter)
 	fmt.Fprintln(f, "---")
 	fmt.Fprint(f, string(js))
 	fmt.Fprintln(f, "---")
+	fmt.Fprintln(f, discovery.ContentRaw)
 
 	err = f.Close()
 	if err != nil {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 
-	"github.com/deta/space/pkg/util/fs"
 	"github.com/deta/space/shared"
 	"gopkg.in/yaml.v2"
 )
@@ -39,38 +37,6 @@ func checkDiscoveryFileCase(sourceDir string) (string, bool, error) {
 		}
 	}
 	return "", false, ErrDiscoveryFileNotFound
-}
-
-// Open open discovery file
-func Open(sourceDir string) ([]byte, error) {
-	var exists bool
-	var err error
-
-	exists, err = fs.FileExists(sourceDir, DiscoveryFilename)
-	if err != nil {
-		return nil, err
-	}
-
-	if !exists {
-		return nil, ErrDiscoveryFileNotFound
-	}
-
-	existingDiscoveryFileName, correctCase, err := checkDiscoveryFileCase(sourceDir)
-	if err != nil {
-		return nil, err
-	}
-
-	if !correctCase {
-		return nil, fmt.Errorf("'%s' must be called exactly %s", existingDiscoveryFileName, DiscoveryFilename)
-	}
-
-	// read raw contents from discovery file
-	c, err := ioutil.ReadFile(filepath.Join(sourceDir, DiscoveryFilename))
-	if err != nil {
-		return nil, fmt.Errorf("failed to read contents of discovery file: %w", err)
-	}
-
-	return c, nil
 }
 
 func CreateDiscoveryFile(name string, discovery shared.DiscoveryData) error {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -4,10 +4,18 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/adrg/frontmatter"
+	cmdShared "github.com/deta/space/cmd/shared"
+	"github.com/deta/space/internal/spacefile"
+	"github.com/deta/space/pkg/components/emoji"
+	"github.com/deta/space/pkg/components/styles"
 	"github.com/deta/space/pkg/util/fs"
+	"github.com/deta/space/shared"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -68,4 +76,59 @@ func Open(sourceDir string) ([]byte, error) {
 	}
 
 	return c, nil
+}
+
+func CreateDiscoveryFile(filename string, discovery shared.DiscoveryFrontmatter) error {
+	f, err := os.Create(filename)
+	if err != nil {
+		f.Close()
+		return err
+	}
+
+	js, _ := yaml.Marshal(discovery)
+	fmt.Fprintln(f, "---")
+	fmt.Fprint(f, string(js))
+	fmt.Fprintln(f, "---")
+
+	err = f.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func MigrateAppNameToDiscovery(projectDir string, s *spacefile.Spacefile) {
+	discoveryData := &shared.DiscoveryFrontmatter{}
+
+	df, err := Open(projectDir)
+	if err != nil {
+		if !errors.Is(err, ErrDiscoveryFileNotFound) {
+			cmdShared.Logger.Println(styles.Errorf("\n%s Failed to read Discovery file, %v", emoji.ErrorExclamation, err))
+			return
+		}
+	} else {
+		rest, err := frontmatter.Parse(strings.NewReader(string(df)), &discoveryData)
+		if err != nil {
+			cmdShared.Logger.Println(styles.Errorf("\n%s Failed to parse Discovery file, %v", emoji.ErrorExclamation, err))
+			return
+		}
+		discoveryData.ContentRaw = string(rest)
+	}
+
+	discoveryData.AppName = s.AppName
+	err = CreateDiscoveryFile("Discovery.md", *discoveryData)
+	if err != nil {
+		cmdShared.Logger.Println(styles.Errorf("\n%s Failed to create Discovery file, %v", emoji.ErrorExclamation, err))
+		cmdShared.Logger.Println(styles.Error("\nPlease manually move the app_name from the Spacefile to the Discovery.md file before pushing."))
+		return
+	}
+
+	s.AppName = ""
+
+	err = s.Save(projectDir)
+	if err != nil {
+		cmdShared.Logger.Println(styles.Errorf("\n%s failed to modify spacefile in %s, %w", emoji.ErrorExclamation, projectDir, err))
+		return
+	}
 }

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/adrg/frontmatter"
 	cmdShared "github.com/deta/space/cmd/shared"
@@ -79,20 +78,7 @@ func Open(sourceDir string) ([]byte, error) {
 	return c, nil
 }
 
-func GetDiscoveryFileLastChanged(sourceDir string) (time.Time, error) {
-	p := filepath.Join(sourceDir, DiscoveryFilename)
-	file, err := os.Stat(p)
-
-	if err != nil {
-		return time.Time{}, err
-	}
-
-	modifiedtime := file.ModTime()
-
-	return modifiedtime, nil
-}
-
-func CreateDiscoveryFile(sourceDir string, discovery shared.DiscoveryFrontmatter) error {
+func CreateDiscoveryFile(sourceDir string, discovery shared.DiscoveryData) error {
 	p := filepath.Join(sourceDir, DiscoveryFilename)
 	f, err := os.Create(p)
 	if err != nil {
@@ -115,7 +101,7 @@ func CreateDiscoveryFile(sourceDir string, discovery shared.DiscoveryFrontmatter
 }
 
 func MigrateAppNameToDiscovery(projectDir string, s *spacefile.Spacefile) {
-	discoveryData := &shared.DiscoveryFrontmatter{}
+	discoveryData := &shared.DiscoveryData{}
 
 	df, err := Open(projectDir)
 	if err != nil {

--- a/internal/runtime/.spaceignore
+++ b/internal/runtime/.spaceignore
@@ -1,6 +1,7 @@
 # space
 .space
 .spaceignore
+Discovery.md
 
 # version control
 .hg

--- a/pkg/util/fs/fs.go
+++ b/pkg/util/fs/fs.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 func UnzipTemplates(rootZip []byte, dest string, rootDir string) error {
@@ -119,4 +120,16 @@ func CheckIfAnyFileExists(dir string, filenames ...string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func GetFileLastChanged(name string) (time.Time, error) {
+	file, err := os.Stat(name)
+
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	modifiedtime := file.ModTime()
+
+	return modifiedtime, nil
 }

--- a/shared/types.go
+++ b/shared/types.go
@@ -143,7 +143,7 @@ type DiscoveryFrontmatter struct {
 	ThemeColor string `yaml:"theme_color,omitempty" json:"theme_color"`
 	Git        string `yaml:"git,omitempty" json:"git"`
 	Homepage   string `yaml:"homepage,omitempty" json:"homepage"`
-	ContentRaw string `yaml:"content_raw,omitempty" json:"content_raw"`
+	ContentRaw string `yaml:"-" json:"content_raw"`
 }
 
 func (m Micro) Type() string {

--- a/shared/types.go
+++ b/shared/types.go
@@ -136,6 +136,16 @@ type Micro struct {
 	Dev          string   `yaml:"dev,omitempty"`
 }
 
+type DiscoveryFrontmatter struct {
+	AppName    string `yaml:"app_name,omitempty" json:"app_name"`
+	Title      string `yaml:"title,omitempty" json:"title"`
+	Tagline    string `yaml:"tagline,omitempty" json:"tagline"`
+	ThemeColor string `yaml:"theme_color,omitempty" json:"theme_color"`
+	Git        string `yaml:"git,omitempty" json:"git"`
+	Homepage   string `yaml:"homepage,omitempty" json:"homepage"`
+	ContentRaw string `yaml:"content_raw,omitempty" json:"content_raw"`
+}
+
 func (m Micro) Type() string {
 	if m.Primary {
 		return "primary"

--- a/shared/types.go
+++ b/shared/types.go
@@ -136,7 +136,7 @@ type Micro struct {
 	Dev          string   `yaml:"dev,omitempty"`
 }
 
-type DiscoveryFrontmatter struct {
+type DiscoveryData struct {
 	AppName    string `yaml:"app_name,omitempty" json:"app_name"`
 	Title      string `yaml:"title,omitempty" json:"title"`
 	Tagline    string `yaml:"tagline,omitempty" json:"tagline"`


### PR DESCRIPTION
This PR updates the CLI to use our new publishing flow. The major changes are:

- move `app_name` from `Spacefile` to `Discovery.md` file
- remove uploading of `Discovery.md` file during `space push`
- parse `Discovery.md` file during `space release` and store Discovery data as part of the release
- prompt the dev for an app name and description if no `Discovery.md` file is found
- warn the dev if their local `Discovery.md` file is out of sync with the Discovery data from the previous release