### PR TITLE
[bugfix] ignore interactive question when use latest flag

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -39,7 +39,6 @@ func newCmdRelease() *cobra.Command {
 			releaseNotes, _ := cmd.Flags().GetString("notes")
 			revisionID, _ := cmd.Flags().GetString("rid")
 			
-			, _ := cmd.Flags().GetBool("confirm")
 			listedRelease, _ := cmd.Flags().GetBool("listed")
 			releaseVersion, _ := cmd.Flags().GetString("version")
 			useLatestRevision, _ := cmd.Flags().GetBool("latest")

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -38,9 +38,11 @@ func newCmdRelease() *cobra.Command {
 			projectID, _ := cmd.Flags().GetString("id")
 			releaseNotes, _ := cmd.Flags().GetString("notes")
 			revisionID, _ := cmd.Flags().GetString("rid")
-			useLatestRevision, _ := cmd.Flags().GetBool("confirm")
+			
+			, _ := cmd.Flags().GetBool("confirm")
 			listedRelease, _ := cmd.Flags().GetBool("listed")
 			releaseVersion, _ := cmd.Flags().GetString("version")
+			useLatestRevision, _ := cmd.Flags().GetBool("latest")
 
 			if !cmd.Flags().Changed("id") {
 				projectMeta, err := runtime.GetProjectMeta(projectDir)
@@ -51,7 +53,7 @@ func newCmdRelease() *cobra.Command {
 			}
 
 			if !cmd.Flags().Changed("rid") {
-				if !cmd.Flags().Changed("confirm") {
+				if !cmd.Flags().Changed("latest") && !cmd.Flags().Changed("confirm") {
 					useLatestRevision, err = confirm.Run("Do you want to use the latest revision?")
 					if err != nil {
 						os.Exit(1)


### PR DESCRIPTION
Even if the --latest flag is used in the latest version, it will still enter the interactive command, which is not very friendly in CI.

![image](https://user-images.githubusercontent.com/424491/230732652-1ebdabad-7b7c-43ab-a72a-19fbd6c36fc0.png)
