### PR TITLE
Update: add `.output/` directory to `.spaceignore`

### DIFF
--- a/internal/runtime/.spaceignore
+++ b/internal/runtime/.spaceignore
@@ -12,6 +12,7 @@
 # build
 build
 dist
+.output/
 
 # js frameworks
 .next


### PR DESCRIPTION
Nuxt3 packages the production build in `.output/` directory. https://nuxt.com/docs/guide/directory-structure/output#output-directory