### PR TITLE
Use RunE instead of Run when running commands, and avoid using os.Exit(1)  except in the main.go file.

### DIFF
--- a/cmd/dev/proxy.go
+++ b/cmd/dev/proxy.go
@@ -27,7 +27,7 @@ func newCmdDevProxy() *cobra.Command {
 The micros will be automatically discovered and proxied to.`,
 		PreRunE:  shared.CheckProjectInitialized("dir"),
 		PostRunE: shared.CheckLatestVersion,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
 			directory, _ := cmd.Flags().GetString("dir")
@@ -39,14 +39,15 @@ The micros will be automatically discovered and proxied to.`,
 				port, err = GetFreePort(devDefaultPort)
 				if err != nil {
 					shared.Logger.Printf("%s Failed to get free port: %s", emoji.ErrorExclamation, err)
-					os.Exit(1)
+					return err
 				}
 			}
 
 			if err := devProxy(directory, host, port, open); err != nil {
-				os.Exit(1)
+				return err
 			}
 
+			return nil
 		},
 	}
 
@@ -68,7 +69,7 @@ func devProxy(projectDir string, host string, port int, open bool) error {
 	if entries, err := os.ReadDir(microDir); err != nil || len(entries) == 0 {
 		shared.Logger.Printf("%s No running micros detected.", emoji.X)
 		shared.Logger.Printf("L Use %s to manually start a micro", styles.Blue("space dev up <micro>"))
-		os.Exit(1)
+		return err
 	}
 
 	reverseProxy, err := proxyFromDir(spacefile.Micros, microDir)

--- a/cmd/dev/root.go
+++ b/cmd/dev/root.go
@@ -58,7 +58,7 @@ The cli will start one process for each of your micros, then expose a single enp
 
 		PreRunE:  shared.CheckAll(shared.CheckProjectInitialized("dir"), shared.CheckNotEmpty("id")),
 		PostRunE: shared.CheckLatestVersion,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 
 			projectDir, _ := cmd.Flags().GetString("dir")
@@ -71,20 +71,22 @@ The cli will start one process for each of your micros, then expose a single enp
 				projectID, err = runtime.GetProjectID(projectDir)
 				if err != nil {
 					shared.Logger.Printf("%s Failed to get project id: %s", emoji.ErrorExclamation, err)
-					os.Exit(1)
+					return err
 				}
 			}
 
 			if !cmd.Flags().Changed("port") {
 				port, err = GetFreePort(devDefaultPort)
 				if err != nil {
-					os.Exit(1)
+					return err
 				}
 			}
 
 			if err := dev(projectDir, projectID, host, port, open); err != nil {
-				os.Exit(1)
+				return err
 			}
+
+			return nil
 		},
 	}
 
@@ -131,7 +133,7 @@ func dev(projectDir string, projectID string, host string, port int, open bool) 
 	addr := fmt.Sprintf("%s:%d", host, port)
 	if err != nil {
 		shared.Logger.Printf("%s Error generating the project key", emoji.ErrorExclamation)
-		os.Exit(1)
+		return err
 	}
 
 	shared.Logger.Printf("\n%s Checking for running micros...", emoji.Eyes)

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -19,7 +19,7 @@ func newCmdExec() *cobra.Command {
 The data key will be automatically injected into the command's environment.`,
 		Args:     cobra.MinimumNArgs(1),
 		PostRunE: shared.CheckLatestVersion,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			projectID, _ := cmd.Flags().GetString("project")
 			if !cmd.Flags().Changed("project") {
@@ -27,13 +27,15 @@ The data key will be automatically injected into the command's environment.`,
 				projectID, err = runtime.GetProjectID(cwd)
 				if err != nil {
 					shared.Logger.Printf("project id not provided and could not be inferred from current working directory")
-					os.Exit(1)
+					return err
 				}
 			}
 
 			if err := execRun(projectID, args); err != nil {
-				os.Exit(1)
+				return err
 			}
+
+			return nil
 		},
 	}
 

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/deta/space/cmd/shared"
 	"github.com/deta/space/internal/api"
@@ -20,7 +19,7 @@ func newCmdLink() *cobra.Command {
 		Use:      "link [flags]",
 		Short:    "Link a local directory with an existing project",
 		PostRunE: shared.CheckLatestVersion,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			projectDir, _ := cmd.Flags().GetString("dir")
 			projectID, _ := cmd.Flags().GetString("id")
@@ -29,13 +28,15 @@ func newCmdLink() *cobra.Command {
 				shared.Logger.Printf("Grab the %s of the project you want to link to using Teletype.\n\n", styles.Code("Project ID"))
 
 				if projectID, err = selectLinkProjectID(); err != nil {
-					os.Exit(1)
+					return err
 				}
 			}
 
 			if err := link(projectDir, projectID); err != nil {
-				os.Exit(1)
+				return err
 			}
+
+			return nil
 		},
 		PreRunE: shared.CheckAll(
 			shared.CheckExists("dir"),

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -22,7 +22,7 @@ func newCmdLogin() *cobra.Command {
 		Short:    "Login to space",
 		PostRunE: shared.CheckLatestVersion,
 		Args:     cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			withToken, _ := cmd.Flags().GetBool("with-token")
 
@@ -31,7 +31,7 @@ func newCmdLogin() *cobra.Command {
 				input, err := io.ReadAll(os.Stdin)
 				if err != nil {
 					shared.Logger.Println("failed to read access token from standard input")
-					os.Exit(1)
+					return err
 				}
 
 				accessToken = strings.TrimSpace(string(input))
@@ -39,14 +39,16 @@ func newCmdLogin() *cobra.Command {
 				shared.Logger.Printf("To authenticate the Space CLI with your Space account, generate a new %s in your Space settings and paste it below:\n\n", styles.Code("access token"))
 				accessToken, err = inputAccessToken()
 				if err != nil {
-					os.Exit(1)
+					return err
 				}
 			}
 
 			if err := login(accessToken); err != nil {
 				shared.Logger.Printf(styles.Errorf("%s Failed to login: %v", emoji.ErrorExclamation, err))
-				os.Exit(1)
+				return err
 			}
+
+			return nil
 		},
 	}
 

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -23,7 +23,7 @@ func newCmdNew() *cobra.Command {
 		Use:      "new [flags]",
 		Short:    "Create new project",
 		PostRunE: shared.CheckLatestVersion,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			projectDir, _ := cmd.Flags().GetString("dir")
 			blankProject, _ := cmd.Flags().GetBool("blank")
 			projectName, _ := cmd.Flags().GetString("name")
@@ -32,19 +32,21 @@ func newCmdNew() *cobra.Command {
 				abs, err := filepath.Abs(projectDir)
 				if err != nil {
 					shared.Logger.Printf("%sError getting absolute path of project directory: %s", styles.ErrorExclamation, err.Error())
-					os.Exit(1)
+					return err
 				}
 
 				name := filepath.Base(abs)
 				projectName, err = selectProjectName(name)
 				if err != nil {
-					os.Exit(1)
+					return err
 				}
 			}
 
 			if err := newProject(projectDir, projectName, blankProject); err != nil {
-				os.Exit(1)
+				return err
 			}
+
+			return nil
 		},
 		PreRunE: shared.CheckAll(
 			shared.CheckExists("dir"),

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/deta/space/cmd/shared"
 	"github.com/deta/space/internal/runtime"
@@ -18,7 +17,7 @@ func newCmdOpen() *cobra.Command {
 		PreRunE:  shared.CheckAll(shared.CheckExists("dir"), shared.CheckNotEmpty("id")),
 		PostRunE: shared.CheckLatestVersion,
 
-		Run: open,
+		RunE: open,
 	}
 
 	cmd.Flags().StringP("id", "i", "", "project id of project to open")
@@ -27,7 +26,7 @@ func newCmdOpen() *cobra.Command {
 	return cmd
 }
 
-func open(cmd *cobra.Command, args []string) {
+func open(cmd *cobra.Command, args []string) error {
 
 	projectDir, _ := cmd.Flags().GetString("dir")
 	projectID, _ := cmd.Flags().GetString("id")
@@ -37,14 +36,15 @@ func open(cmd *cobra.Command, args []string) {
 		projectID, err = runtime.GetProjectID(projectDir)
 		if err != nil {
 			shared.Logger.Printf("%s Failed to get project id: %s", emoji.ErrorExclamation, err)
-			os.Exit(1)
+			return err
 		}
 	}
 
 	shared.Logger.Printf("Opening project in default browser...\n")
 	if err := browser.OpenURL(fmt.Sprintf("%s/%s", shared.BuilderUrl, projectID)); err != nil {
 		shared.Logger.Printf("%s Failed to open browser window %s", emoji.ErrorExclamation, err)
-		os.Exit(1)
+		return err
 	}
 
+	return nil
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -34,7 +34,7 @@ Tip: Use the .spaceignore file to exclude certain files and directories from bei
 		Args:     cobra.NoArgs,
 		PreRunE:  shared.CheckAll(shared.CheckProjectInitialized("dir"), shared.CheckNotEmpty("id", "tag")),
 		PostRunE: shared.CheckLatestVersion,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			projectDir, _ := cmd.Flags().GetString("dir")
 			projectID, _ := cmd.Flags().GetString("id")
 			if !cmd.Flags().Changed("id") {
@@ -42,7 +42,7 @@ Tip: Use the .spaceignore file to exclude certain files and directories from bei
 				projectID, err = runtime.GetProjectID(projectDir)
 				if err != nil {
 					shared.Logger.Printf("%s Failed to get project id: %s", emoji.ErrorExclamation, err)
-					os.Exit(1)
+					return err
 				}
 			}
 
@@ -52,8 +52,9 @@ Tip: Use the .spaceignore file to exclude certain files and directories from bei
 
 			err := push(projectID, projectDir, pushTag, openInBrowser, skipLogs)
 			if err != nil {
-				os.Exit(1)
+				return err
 			}
+			return nil
 		},
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,5 +34,9 @@ Complete documentation available at %s`, shared.DocsUrl),
 	cmd.AddCommand(newCmdValidate())
 	cmd.AddCommand(newCmdRelease())
 
+	// XXX: This will prevent the usage from being displayed when an error occurs 
+	// while calling the Execute function in the main.go file.
+	cmd.SilenceUsage = true
+
 	return cmd
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/deta/space/cmd/shared"
@@ -18,11 +17,13 @@ func newCmdValidate() *cobra.Command {
 		Use:      "validate [flags]",
 		Short:    "Validate your Spacefile and check for errors",
 		PostRunE: shared.CheckLatestVersion,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			projectDir, _ := cmd.Flags().GetString("dir")
 			if err := validate(projectDir); err != nil {
-				os.Exit(1)
+				return err
 			}
+
+			return nil
 		},
 		PreRunE: shared.CheckExists("dir"),
 	}


### PR DESCRIPTION
Hello, 

This PR will replace the cobra Run method with RunE, which will return an error instead of silently exiting. The error will be passed to the main.go file when calling the Execute function.