### PR TITLE
update go releaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,8 +25,8 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -X github.com/deta/space/cmd/shared.SpaceVersion={{ .Version }}
-      - -X github.com/deta/space/cmd/shared.Platform={{ .Env.GOARCH }}-{{ .Env.GOOS }}
+      - -X github.com/deta/space/cmd/utils.SpaceVersion={{ .Version }}
+      - -X github.com/deta/space/cmd/utils.Platform={{ .Env.GOARCH }}-{{ .Env.GOOS }}
     goos:
       - darwin
     goarch:
@@ -39,8 +39,8 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -X github.com/deta/space/cmd/shared.SpaceVersion={{ .Version }}
-      - -X github.com/deta/space/cmd/shared.Platform={{ .Env.GOARCH }}-{{ .Env.GOOS }}
+      - -X github.com/deta/space/cmd/utils.SpaceVersion={{ .Version }}
+      - -X github.com/deta/space/cmd/utils.Platform={{ .Env.GOARCH }}-{{ .Env.GOOS }}
     goos:
       - darwin
     goarch:


### PR DESCRIPTION
- add `space api` command, and `SPACE_ROOT` env (#109)
- add experimental provide_actions flag, fix api method not set properly (#110)
- don't set empty env in space dev (#112)
- add instruction to wire the space cli to staging
- add a new command to print the access token (#113)
- add a `--jq` flag for `space api` cmd (#114)
- fix post request, add patch and delete method (#116)
- Add support for actions (#115)
- fix space version (#117)
- chore: update goreleaser config for space version ldflags
