### PR TITLE
chore: update docs url

### DIFF
--- a/cmd/utils/shared.go
+++ b/cmd/utils/shared.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	DocsUrl          = "https://deta.space/docs"
-	SpacefileDocsUrl = "https://deta.space/docs/en/reference/spacefile"
+	SpacefileDocsUrl = "https://go.deta.dev/docs/spacefile/v0"
 	BuilderUrl       = "https://deta.space/builder"
 )
 


### PR DESCRIPTION
Replaces the old docs URL with the shortened one that will point to the new docs.