### PR TITLE
Create .gitignore inside .space instead of writing to existing file

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -66,11 +66,6 @@ func selectLinkProjectID() (string, error) {
 }
 
 func link(projectDir string, projectID string) error {
-	if err := runtime.AddSpaceToGitignore(projectDir); err != nil {
-		utils.Logger.Println("failed to add .space to .gitignore, %w", err)
-		return err
-	}
-
 	projectRes, err := utils.Client.GetProject(&api.GetProjectRequest{ID: projectID})
 	if err != nil {
 		if errors.Is(auth.ErrNoAccessTokenFound, err) {

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -154,12 +154,6 @@ func newProject(projectDir, projectName string, blankProject bool) error {
 		}
 	}
 
-	// add .space folder to gitignore
-	if err := runtime.AddSpaceToGitignore(projectDir); err != nil {
-		utils.Logger.Printf("failed to add .space to gitignore: %s", err)
-		return err
-	}
-
 	// Create project
 	meta, err := createProject(projectName)
 	if err != nil {

--- a/internal/runtime/manager.go
+++ b/internal/runtime/manager.go
@@ -3,11 +3,9 @@ package runtime
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"regexp"
 )
 
 const (
@@ -41,6 +39,9 @@ func StoreProjectMeta(projectDir string, p *ProjectMeta) error {
 
 	spaceReadmeNotes := "Don't commit this folder (.space) to git as it may contain security-sensitive data."
 	ioutil.WriteFile(filepath.Join(projectDir, spaceDir, "README"), []byte(spaceReadmeNotes), filePermMode)
+
+	// Add a .gitignore file so .space is not committed to git
+	ioutil.WriteFile(filepath.Join(projectDir, spaceDir, ".gitignore"), []byte("*\n"), filePermMode)
 
 	return ioutil.WriteFile(filepath.Join(projectDir, spaceDir, projectMetaFile), marshalled, filePermMode)
 }
@@ -80,43 +81,4 @@ func IsProjectInitialized(projectDir string) (bool, error) {
 		return false, err
 	}
 	return true, nil
-}
-
-// AddSpaceToGitignore add .space to .gitignore
-func AddSpaceToGitignore(projectDir string) error {
-	gitignorePath := filepath.Join(projectDir, ".gitignore")
-	gitignoreExists := true
-
-	_, err := os.Stat(gitignorePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			gitignoreExists = false
-		}
-	}
-
-	if gitignoreExists {
-		contents, err := os.ReadFile(gitignorePath)
-		if err != nil {
-			return fmt.Errorf("failed to append .space to .gitignore: %w", err)
-		}
-
-		// check if .space already exists
-		pass, _ := regexp.MatchString(`(?m)^(\.space)\b`, string(contents))
-		if pass {
-			return nil
-		}
-
-		contents = append(contents, []byte("\n.space")...)
-		err = ioutil.WriteFile(gitignorePath, contents, filePermMode)
-		if err != nil {
-			return fmt.Errorf("failed to append .space to .gitignore: %w", err)
-		}
-		return nil
-	}
-
-	err = ioutil.WriteFile(gitignorePath, []byte(".space"), filePermMode)
-	if err != nil {
-		return fmt.Errorf("failed to write .space to .gitignore: %w", err)
-	}
-	return nil
 }


### PR DESCRIPTION
Removes the need to modify user's .gitignore file.
The CLI will now write a new .gitignore inside the .space directory containing the line `*` to ignore everything in the directory.