### PR TITLE
push: properly return a non-nil error when the build is incomplete

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -54,11 +54,7 @@ Tip: Use the .spaceignore file to exclude certain files and directories from bei
 			skipLogs, _ := cmd.Flags().GetBool("skip-logs")
 			experimental, _ := cmd.Flags().GetBool("experimental")
 
-			err := push(projectID, projectDir, pushTag, openInBrowser, skipLogs, experimental)
-			if err != nil {
-				return err
-			}
-			return nil
+			return push(projectID, projectDir, pushTag, openInBrowser, skipLogs, experimental)
 		},
 	}
 
@@ -195,7 +191,7 @@ func push(projectID, projectDir, pushTag string, openInBrowser, skipLogs, experi
 	}
 	if b.Status != api.Complete {
 		utils.Logger.Println(styles.Errorf("\n%s Failed to push code and create a revision. Please try again!", emoji.ErrorExclamation))
-		return err
+		return fmt.Errorf("build isn't complete")
 	}
 
 	// get promotion via build id (build id == revision id)


### PR DESCRIPTION
In the case that build status is incomplete, we used to return a `nil` error value. This patch modifies the code so that an appropriate error is returned.

Fixes #107.