### PR TITLE
internal: runtime: zip: fix the ignoring logic for top level directories

### DIFF
--- a/internal/runtime/zip.go
+++ b/internal/runtime/zip.go
@@ -51,9 +51,14 @@ func ZipDir(sourceDir string) ([]byte, int, error) {
 		if err != nil {
 			return err
 		}
+		if path == absDir {
+			return nil
+		}
 
+		// matching against the the `TrimPrefix`ed transformation so that you can have your
+		// project in a folder called `dist`, for example.
 		// skip if shouldSkip according to skipPaths which are derived from .spaceignore
-		shouldSkip := spaceignore.MatchesPath(path)
+		shouldSkip := spaceignore.MatchesPath(strings.TrimPrefix(path, absDir+"/"))
 		if shouldSkip && info.IsDir() {
 			return filepath.SkipDir
 		}


### PR DESCRIPTION
Before this patch, if the user's project was located in a folder configured to be ignored by the `.spaceignore` file, Space CLI would ignore all of the files and try uploading an empty zip file.

This patch makes it so that ignore rules are only applied to files in the project folder.