### PR TITLE
static micro default serve field

### DIFF
--- a/cmd/utils/messages.go
+++ b/cmd/utils/messages.go
@@ -17,7 +17,7 @@ func ProjectNotes(projectName string, projectId string) string {
 %s Use the %s to configure your app: %s
 %s Push your code to Space with %s`, styles.Bold("Next steps:"), emoji.Eyes,
 		styles.Bold(fmt.Sprintf("%s/%s", BuilderUrl, projectId)),
-		emoji.Files,
+		emoji.File,
 		styles.Code("Spacefile"), styles.Bold(SpacefileDocsUrl),
 		emoji.Swirl,
 		styles.Code("space push"))

--- a/pkg/scanner/runtimes.go
+++ b/pkg/scanner/runtimes.go
@@ -103,6 +103,7 @@ func staticScanner(dir string) (*shared.Micro, error) {
 	m := &shared.Micro{
 		Name:   name,
 		Src:    dir,
+		Serve:  "./",
 		Engine: shared.Static,
 	}
 	return m, nil


### PR DESCRIPTION
Adds a default `Serve` field for static micros: `./`, so that the src folder is served by default.

Also modifies the message shown by `space new` on completion, from:
![from](https://i.imgur.com/DXAHHuO.png)
to:
![to](https://i.imgur.com/GEq8BcE.png)